### PR TITLE
Issue #35: Fix TLPButton Component, make the button clickable wherever it is clicked

### DIFF
--- a/react-frontend/components/TLPButton.tsx
+++ b/react-frontend/components/TLPButton.tsx
@@ -48,7 +48,7 @@ type buttonprops = {
   width?: DimensionValue;
   height?: DimensionValue;
   accessibilityLabel: AccessibilityProps['accessibilityLabel'];
-  onPress: ((event: GestureResponderEvent) => void) | null | undefined,
+  onPress: ((event: GestureResponderEvent) => void) | undefined,
   buttonText: any,
   icon: any,
   otherProps: any
@@ -94,7 +94,7 @@ export default function StyledButton(buttonProps:buttonprops): JSX.Element {
     <Pressable
       onPress={onPress}
       style={[styles.buttonContainer, {backgroundColor: backgroundColor, width: width, height: height}, otherProps]}>
-      <TouchableOpacity>
+      <TouchableOpacity onPress={onPress}>
         {/* {icon ? (
           <Icon.Button
             name={icon}


### PR DESCRIPTION
Fixes in TLPButton.tsx:
- Added `onPress={onPress}` to `<TouchableOpacity>` to make the text clickable, since the title is inside `<Text>` inside `<TouchableOpacity>`. `TouchableOpacity` did not inherit the `onPress` touch event from `<Pressable>`
- Inside `buttonprops`, changed `onPress` from `((event: GestureResponderEvent) => void) | null | undefined` to `((event: GestureResponderEvent) => void) | undefined` to match its type in `TouchableOpacity`

The result can be seen in the video below:
https://github.com/user-attachments/assets/3c0250cf-278a-4298-9907-d4e4f04792a1

