### PR TITLE
Add Lesson Type to Lesson Authoring Tool

### DIFF
--- a/lesson-authoring/src/collections/Lesson.ts
+++ b/lesson-authoring/src/collections/Lesson.ts
@@ -1,38 +1,38 @@
-import LessonAdminComponent, { LessonAdminComponentProps } from '@/app/(payload)/admin/components/LessonAdminComponent';
 import type { CollectionConfig } from 'payload'
 
 export const Lesson: CollectionConfig = {
   slug: 'lessons',
   fields: [
     {
-        name: 'cover',
-        type: 'group',
-        fields: [
-            {
-                name: 'title',
-                type: 'text',
-                required: true,
-            },
-            {
-                name: 'description',
-                type: 'text',
-            },
-            {
-                name: 'image',
-                type: 'upload',
-                relationTo: 'media',
-            },
-        ]
+        name: 'title',
+        type: 'text',
+        required: true,
     },
     {
-      name: 'introduction',
+        name: 'description',
+        type: 'text',
+        required: true,
+    },
+    {
+        name: 'thumbnail',
+        type: 'upload',
+        relationTo: 'media',
+        required: true,
+    },  
+    { // allows the user to add 
+      name: 'activities',
       type: 'array',
       fields: [
         {
-          name: 'dialogue',
-          type: 'text',
+          name: 'activity',
+          type: 'ui',
+          admin: {
+            components: {
+              Field: "@/fields/ActivityField",
+            }
+          }
         },
       ],
     },
-  ],
+  ], //end of fields
 }


### PR DESCRIPTION
Fixes #92

- User can read, add, update and delete a lesson in the lesson authoring tool